### PR TITLE
修复了 visual 模式下的文字范围选取错误，修复了函数在 visual 模式下会每行执行一次导致的 bug

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,6 +3,7 @@ FileName: gtrans.vim
 Desc: Google Translate Plugin for Vim (Need python)
 
 Install: 把文件复制到 `$VIM/plugin/` 目录下即可，插件需要 Python 的支持。
+Or: add Bundle 'bolasblack/gtrans.vim' in vimrc file then run :BundleInstall
 
 History: 
 

--- a/plugin/gtrans.vim
+++ b/plugin/gtrans.vim
@@ -83,6 +83,7 @@ endfunc
 
 " ]]]
 
+"from https://stackoverflow.com/a/6271254/4869088 via @xolox
 func! s:GetVisual() range
     let [lnum1, col1] = getpos("'<")[1:2]
     let [lnum2, col2] = getpos("'>")[1:2]

--- a/plugin/gtrans.vim
+++ b/plugin/gtrans.vim
@@ -75,7 +75,7 @@ func! GetTrans(...) " [[[
     call s:Translate(eval("expand('<cword>')"), targetLang)
 endfunc
 
-func! GetTransVis()
+func! GetTransVis() range
     let targetLang = g:gtrans_DefaultLang
     let visText = s:GetVisual()
     call s:Translate(visText, targetLang)
@@ -83,32 +83,14 @@ endfunc
 
 " ]]]
 
-func! s:GetVisual() " [[[
-	let firstcol= col("'<")
-	let lastcol= col("'>")
-	let firstline = line("'<")
-	let lastline = line("'>")
-	let str = ''
-	if firstline == lastline 
-		let ll  = getline(firstline)
-		let str = strpart(ll,firstcol-1,lastcol-firstcol)
-	else
-		let lcount = firstline+1
-		let lines = []
-		let ll  = strpart(getline(firstline),firstcol-1)
-		call add(lines,ll)
-		while lcount < lastline
-			let ll = getline(lcount)
-			call add(lines,ll)
-			let lcount += 1
-		endw
-		let ll = strpart(getline(lcount),0,lastcol-1)
-		call add(lines,ll)
-		let str = join(lines,"\n")
-	endif
-	return str
+func! s:GetVisual() range
+    let [lnum1, col1] = getpos("'<")[1:2]
+    let [lnum2, col2] = getpos("'>")[1:2]
+    let lines = getline(lnum1, lnum2)
+    let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
+    let lines[0] = lines[0][col1 - 1:]
+    return join(lines, " ")
 endfunc
-" ]]]
 
 func! s:Translate(text, tl) " [[[
 python << EOF


### PR DESCRIPTION
原有的 visual 选取函数在 visual 模式下没有正确选取单词，例如使用 v 进入 visual 模式，使用 e 跳转到单词末尾，此时原有的代码会漏选单词的最后一个字符，造成翻译错误。

原有的代码在 visual 模式下会对每行执行一次，造成翻译时出现 bug。

测试环境 vim8 +python